### PR TITLE
Quitando using Microsoft.AspNet.Identity.EntityFramework innecesario.

### DIFF
--- a/ProyectoFinalDotNet8/ProyectoFinalDotNet8/Controllers/UsuersController.cs
+++ b/ProyectoFinalDotNet8/ProyectoFinalDotNet8/Controllers/UsuersController.cs
@@ -1,5 +1,4 @@
 ﻿//using Microsoft.AspNetCore.Http;
-using Microsoft.AspNet.Identity.EntityFramework;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;


### PR DESCRIPTION
Quitando using Microsoft.AspNet.Identity.EntityFramework innecesario.